### PR TITLE
Fix CalDAVPlugin Compatibility

### DIFF
--- a/lib/Foswiki/Plugins/CalendarPlugin/Core.pm
+++ b/lib/Foswiki/Plugins/CalendarPlugin/Core.pm
@@ -485,7 +485,7 @@ MESSAGE
                 "VIEW", $session->{user}, undef, $evTopic, $evWeb
             ) ) {
             my ($meta, $evText) = Foswiki::Func::readTopic( $evWeb, $evTopic );
-            $text .= $evText;
+            $text .= $meta->expandMacros($evText);
         }
     }
 


### PR DESCRIPTION
When using CalDAVPlugin, the events are buried in a macro %CalDAV{XXXX}%. Because of this, macros need to be expanded.

**Without this patch**

%Calendar% will receive the raw string %CalDAV{XXXX}%

**With this patch**

%Calendar% will see events from the CalDAV server
